### PR TITLE
feat: Add interactive Kismet installation option

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -898,11 +898,6 @@ case "\$MODE" in
             -c ${WIFI_5GHZ}:name=${WIFI_5GHZ_NAME} \\
             -c ${WIFI_24GHZ}:name=${WIFI_24GHZ_NAME}
         ;;
-    )
-        exec kismet --no-ncurses --override  \\
-            -c ${WIFI_5GHZ}:name=${WIFI_5GHZ_NAME} \\
-            -c ${WIFI_24GHZ}:name=${WIFI_24GHZ_NAME}
-        ;;
     *)
         exec kismet --no-ncurses \\
             -c ${WIFI_5GHZ}:name=${WIFI_5GHZ_NAME} \\


### PR DESCRIPTION
## Summary
- Adds interactive Kismet installation when not found during install
- Supports Debian, Raspbian, and Ubuntu from official Kismet repository
- Automatically adds user to kismet group for non-root capture

## Test plan
- [ ] Run installer on fresh Raspberry Pi OS without Kismet
- [ ] Verify option 1 installs Kismet from repository
- [ ] Verify option 2 exits with proper message
- [ ] Verify existing systems with Kismet skip the prompt

Fixes #12