### PR TITLE
Fix install script: Remove all monitor interfaces + Add Wardrive+BT mode

### DIFF
--- a/install/warpie_config.py
+++ b/install/warpie_config.py
@@ -586,6 +586,10 @@ def configure_kismet_autostart() -> tuple[bool, str]:
                 "   → Optimized for mobile capture\n"
                 "   → Excludes home networks\n"
                 "   → Best for field deployment\n\n"
+                "[dim]□[/dim] [bold]Wardrive+BT[/bold]\n"
+                "   → Mobile capture with Bluetooth scanning\n"
+                "   → Includes WiFi + BT/BTLE devices\n"
+                "   → Higher resource usage\n\n"
                 "[dim]□[/dim] [bold]Normal[/bold]\n"
                 "   → Standard Kismet capture\n"
                 "   → No exclusions applied\n"
@@ -600,6 +604,7 @@ def configure_kismet_autostart() -> tuple[bool, str]:
 
         mode_choices = [
             {"name": "Wardrive - Optimized mobile capture (Recommended)", "value": "wardrive"},
+            {"name": "Wardrive+BT - Mobile capture with Bluetooth", "value": "wardrive_bt"},
             {"name": "Normal - Standard capture, no exclusions", "value": "normal"},
             {"name": "Targeted - OUI prefix filtering", "value": "targeted"},
         ]
@@ -615,6 +620,7 @@ def configure_kismet_autostart() -> tuple[bool, str]:
 
         mode_display = {
             "wardrive": "[green]Wardrive[/green] (mobile capture)",
+            "wardrive_bt": "[bright_magenta]Wardrive+BT[/bright_magenta] (mobile + Bluetooth)",
             "normal": "[yellow]Normal[/yellow] (standard capture)",
             "targeted": "[cyan]Targeted[/cyan] (OUI filtering)",
         }


### PR DESCRIPTION
## Summary

This PR fixes two installation-related bugs:

- **Issue #34**: Uninstaller doesn't remove all monitor interfaces
- **Issue #36**: Installation script missing Wardrive+BT mode option

## Changes

### Fix #34: Uninstaller Monitor Interface Cleanup

**Problem**: Uninstaller only removed monitor interfaces from saved config, leaving orphaned interfaces from previous sessions or manual testing.

**Solution**: 
- Replaced filesystem globbing (`/sys/class/net/*mon*`) with `iw dev` command
- Now detects ALL interfaces ending in "mon" regardless of source
- More reliable detection method using wireless stack directly

**Code Change**:
```bash
# Old (filesystem based)
for iface in /sys/class/net/*mon*; do
    iface_name=$(basename "$iface")
    ...
done

# New (iw dev based)
for iface in $(iw dev | grep -E '^\s+Interface.*mon$' | awk '{print $2}'); do
    ...
done
```

### Fix #36: Add Wardrive+BT Mode to Installation Menu

**Problem**: Installation creates `kismet_wardrive_bt.conf` but doesn't offer it during interactive setup.

**Solution**: Added Wardrive+BT as a selectable startup mode in three places:

1. **warpie_config.py**: Interactive configuration menu
   - Added to mode selection panel
   - Added to mode_choices list
   - Added to mode_display dictionary

2. **install.sh web control panel**: 
   - Added to MODES dictionary
   - Added button to HTML template
   - Updated get_kismet_status() to recognize mode
   - Added active_wardrive_bt template variable

**User Experience**:
```
Startup Capture Mode:

☑ Wardrive (Recommended)
   → Optimized for mobile capture
   → Excludes home networks
   → Best for field deployment

☐ Wardrive+BT
   → Mobile capture with Bluetooth scanning
   → Includes WiFi + BT/BTLE devices
   → Higher resource usage

☐ Normal
☐ Targeted
```

## Testing

- ✅ All 109 bash tests pass
- ✅ Python syntax validated
- ✅ Bash syntax validated
- ✅ No breaking changes to existing functionality

## Impact

- Users can now select Wardrive+BT during installation
- Uninstaller properly cleans up all monitor interfaces
- Better field deployment experience
- Cleaner test environment transitions

Closes #34
Closes #36